### PR TITLE
Fix label_right overwriting labelRight

### DIFF
--- a/src/react-switch-button.js
+++ b/src/react-switch-button.js
@@ -91,7 +91,7 @@ var SwitchButton = React.createClass( {
     }
 
     // @deprecated since 1.0.4 - use labelRight instead - issue #5 https://github.com/gfazioli/react-switch-button/issues/5
-    if( 'undefined' !== this.props.label_right || this.props.label_right != '' ) {
+    if( 'undefined' !== this.props.label_right && this.props.label_right != '' ) {
       this.props.labelRight = this.props.label_right;
     }
 


### PR DESCRIPTION
The old check always returned true as far as I can tell. This also fixed an issue with React 0.14, which removed support for changing `this.props`.
