### PR TITLE
fix proptypes issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-switch-button",
+  "name": "react-switch-button-dev",
   "version": "2.3.2",
   "private": false,
   "description": "A React UI Component to display an awesome Switch (swipe) Button control",
@@ -46,5 +46,8 @@
   "keywords": [
     "react",
     "react-component"
-  ]
+  ],
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-switch-button-dev",
+  "name": "react-switch-button",
   "version": "2.3.3",
   "private": false,
   "description": "A React UI Component to display an awesome Switch (swipe) Button control",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-switch-button-dev",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": false,
   "description": "A React UI Component to display an awesome Switch (swipe) Button control",
   "main": "dist/react-switch-button.min.js",

--- a/src/react-switch-button.jsx
+++ b/src/react-switch-button.jsx
@@ -1,4 +1,5 @@
 import React from "react"
+import PropTypes from 'prop-types';
 
 class SwitchButton extends React.Component {
 
@@ -78,17 +79,17 @@ class SwitchButton extends React.Component {
 }
 
 SwitchButton.propTypes = {
-  id             : React.PropTypes.string,
-  name           : React.PropTypes.string,
-  title          : React.PropTypes.string,
-  label          : React.PropTypes.string,
-  labelRight     : React.PropTypes.string,
-  defaultChecked : React.PropTypes.bool,
-  disabled       : React.PropTypes.bool,
-  theme          : React.PropTypes.string,
-  checked        : React.PropTypes.bool,
-  mode           : React.PropTypes.string,
-  onChange       : React.PropTypes.func
+  id             : PropTypes.string,
+  name           : PropTypes.string,
+  title          : PropTypes.string,
+  label          : PropTypes.string,
+  labelRight     : PropTypes.string,
+  defaultChecked : PropTypes.bool,
+  disabled       : PropTypes.bool,
+  theme          : PropTypes.string,
+  checked        : PropTypes.bool,
+  mode           : PropTypes.string,
+  onChange       : PropTypes.func
 };
 
 SwitchButton.defaultProps = {


### PR DESCRIPTION
- uses external prop-types package instead of `React.PropTypes`

Note : tested using a "dev" version of the npm package to make sure no more issue arises (`npm i react-switch-button-dev`)